### PR TITLE
Instantiate local storage in global and window namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,19 @@ Used to mock `localStorage` to run headless tests of cache implementation in ter
 
     npm install mock-local-storage --save-dev
 
-## Usage node testing
+## Usage
+
+## Mocha
+
+Require in Mocha, which will replace `localStorage` and `sessionStorage` on the `global` and `window` objects:
+
+    mocha --require mock-local-storage
+
+If you are using `jsdom-global`, make sure it is required before `mock-local-storage`:  
+
+    mocha --require jsdom-global --require mock-local-storage
+
+### Other testing frameworks
 
 In a node environment you can mock the `window.localStorage` as follows:
 
@@ -42,14 +54,9 @@ import './mock-localstorage'
 // unit tests follow here
 ```
 
+### Caveats
 
-### Mocha usage example
-
-    mocha -r mock-local-storage
-
-Mocha will require module, which will replace `localStorage` and `sessionStorage` on the `global` object.
-
-There are some caveats with using `index` operator, though. Browser's 
+There are some caveats with using `index` operator. Browser's 
 `localStorage` works with strings and stringifyes objects stored via `localStorage[key]` notation, but this implementation does not.
 
 Additionally, test code can provide a callback to be invoked on item insertion.

--- a/src/mock-localstorage.js
+++ b/src/mock-localstorage.js
@@ -84,4 +84,4 @@
     
     window.localStorage = global.localStorage;
     window.sessionStorage = global.sessionStorage;
-}();
+}());

--- a/src/mock-localstorage.js
+++ b/src/mock-localstorage.js
@@ -1,5 +1,5 @@
 // Mock localStorage 
-(function (glob) {
+(function () {
 
     function createStorage() {
         let s = {},
@@ -75,6 +75,13 @@
         return s;
     }
 
-    glob.localStorage = createStorage();
-    glob.sessionStorage = createStorage();
-}(typeof window !== 'undefined' ? window : global));
+    global.localStorage = createStorage();
+    global.sessionStorage = createStorage();
+    
+    if (typeof window === 'undefined' ) {
+        window = {};
+    }
+    
+    window.localStorage = global.localStorage;
+    window.sessionStorage = global.sessionStorage;
+}();

--- a/src/mock-localstorage.js
+++ b/src/mock-localstorage.js
@@ -79,7 +79,7 @@
     global.sessionStorage = createStorage();
     
     if (typeof window === 'undefined' ) {
-        window = {};
+        global.window = {};
     }
     
     window.localStorage = global.localStorage;


### PR DESCRIPTION
Currently, local storage will be mocked either on `window` (if exists) or `global`. I am using `jsdom-global` to mock some other DOM elements for the mocha test. When `jsdom-global` was referenced first, `mock-local-storage` was mocking only on `window`. This was an issue for me, as in my code I am referencing to `localStorage` from global namespace.

Proposed change would instantiate `localStorage` always in both `window` and `global` namespace.