### PR TITLE
Fix 'global' and 'window' scope by using the 'global' library

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "mocha": "^2.2.1"
   },
   "dependencies": {
-    "core-js": "^0.8.3"
+    "core-js": "^0.8.3",
+    "global": "^4.3.2"
   }
 }

--- a/src/mock-localstorage.js
+++ b/src/mock-localstorage.js
@@ -1,4 +1,4 @@
-// Mock localStorage 
+// Mock localStorage
 (function () {
 
     function createStorage() {
@@ -75,13 +75,12 @@
         return s;
     }
 
+    const global = require("global")
+    const window = require("global/window")
+
     global.localStorage = createStorage();
     global.sessionStorage = createStorage();
-    
-    if (typeof window === 'undefined' ) {
-        global.window = {};
-    }
-    
+
     window.localStorage = global.localStorage;
     window.sessionStorage = global.sessionStorage;
 }());


### PR DESCRIPTION
Now 'global' and 'window' scope should work correctly.
Before it was removing `XMLHttpRequest` from the window scope when created with [xhr-mock](https://github.com/jameslnewell/xhr-mock).
This uses the [global library](https://github.com/Raynos/global), which is also used by xhr-mock.
Fix #9.