### PR TITLE
Update README.md about how to import library

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ In a node environment you can mock the `window.localStorage` as follows:
 
 ```js
 global.window = {}
-import localStorage from 'mock-local-storage'
+import 'mock-local-storage'
 window.localStorage = global.localStorage
 ```
 
@@ -42,7 +42,7 @@ You can even store this in a file that is reused across tests:
 
 ```js
 global.window = {}
-import localStorage from 'mock-local-storage'
+import 'mock-local-storage'
 window.localStorage = global.localStorage
 ```
 


### PR DESCRIPTION
Since [this file](https://github.com/letsrock-today/mock-local-storage/blob/master/src/mock-localstorage.js) just apply side effect on `global` and `window` object and export nothing, we can update syntax on README to just import the library.